### PR TITLE
Improve speed when determining last deploy tag

### DIFF
--- a/lib/fa-harness-tools/check_recent_deploy.rb
+++ b/lib/fa-harness-tools/check_recent_deploy.rb
@@ -42,7 +42,7 @@ module FaHarnessTools
         return true, "first deploy"
       end
 
-      latest_allowed_rev = latest_allowed_tag[:commit][:sha]
+      latest_allowed_rev = @client.get_commit_sha_from_tag(latest_allowed_tag)
       rev = @context.new_commit_sha
 
       if @client.is_ancestor_of?(latest_allowed_rev, rev)

--- a/spec/check_recent_deploy_spec.rb
+++ b/spec/check_recent_deploy_spec.rb
@@ -17,16 +17,17 @@ describe FaHarnessTools::CheckRecentDeploy do
     end
     let(:git_tags) do
       [
-        { name: "harness-deploy-production-2019-10-29T10-10-00Z", commit: { sha: "456789" } },
-        { name: "harness-deploy-production-2019-10-28T11-20-00Z", commit: { sha: "345678" } },
-        { name: "harness-deploy-production-2019-10-27T12-30-00Z", commit: { sha: "234567" } },
-        { name: "harness-deploy-production-2019-10-26T13-40-00Z", commit: { sha: "123456" } },
+        { name: "harness-deploy-production-2019-10-29T10-10-00Z", tag_sha: "400000" },
+        { name: "harness-deploy-production-2019-10-28T11-20-00Z", tag_sha: "300000" },
+        { name: "harness-deploy-production-2019-10-27T12-30-00Z", tag_sha: "500000" },
+        { name: "harness-deploy-production-2019-10-26T13-40-00Z", tag_sha: "900000" },
       ]
     end
 
     before do
       allow(harness_context).to receive(:environment).and_return("production")
       allow(client).to receive(:all_deploy_tags).and_return(git_tags)
+      allow(client).to receive(:get_commit_sha_from_tag).with(git_tags[2]).and_return("234567")
     end
 
     context "with no git tags" do
@@ -41,8 +42,12 @@ describe FaHarnessTools::CheckRecentDeploy do
     context "with one git tag" do
       let(:git_tags) do
         [
-          { name: "harness-deploy-production-2019-10-26T13-40-00Z", commit: { sha: "123456" } },
+          { name: "harness-deploy-production-2019-10-26T13-40-00Z", commit: { sha: "200000" } },
         ]
+      end
+
+      before do
+        allow(client).to receive(:get_commit_sha_from_tag).with(git_tags[0]).and_return("123456")
       end
 
       it "returns true when deploying only existing tag" do

--- a/spec/github_client_spec.rb
+++ b/spec/github_client_spec.rb
@@ -1,0 +1,76 @@
+describe FaHarnessTools::GithubClient do
+  subject do
+    described_class.new(
+      oauth_token: "none",
+      owner: "fac",
+      repo: "example",
+    )
+  end
+
+  let(:octokit) { instance_double(Octokit::Client) }
+
+  before do
+    expect(Octokit::Client).to receive(:new).with(access_token: "none").and_return(octokit)
+  end
+
+  describe "#get_commit_sha_from_tag" do
+    it "returns the commit SHA from a lightweight tag" do
+      tag_data = {
+        ref: "refs/tags/example-tag",
+        node_id: "MDM6UmVmMTc0MzU5Mzc6cmVmcy90YWdzL2hhcm5lc3MtZGVwbG95LXByb2QtMjAyMC0wNS0yMFQxMC0yNC0wN1o=",
+        url: "https://api.github.com/repos/fac/example/git/refs/tags/example-tag",
+        object: {
+          sha: "e7eabe7dd1fbe7ddf75746b6203da819e8abb65c",
+          type: "commit",
+          url: "https://api.github.com/repos/fac/example/git/commits/e7eabe7dd1fbe7ddf75746b6203da819e8abb65c",
+        },
+      }
+
+      expect(subject.get_commit_sha_from_tag(tag_data)).to eq("e7eabe7dd1fbe7ddf75746b6203da819e8abb65c")
+    end
+
+    it "returns the commit SHA from an annotated tag" do
+      tag_data = {
+        ref: "refs/tags/example-tag",
+        node_id: "MDM6UmVmMTc0MzU5Mzc6cmVmcy90YWdzL2RlcGxveS1wcm9kdWN0aW9uLTIwMTctMTAtMDZUMTMtNTgtMzNa",
+        url: "https://api.github.com/repos/fac/example/git/refs/tags/example-tag",
+        object: {
+          sha: "a199d3365096c52d263b291c681f1e6b80a58a0a",
+          type: "tag",
+          url: "https://api.github.com/repos/fac/example/git/tags/a199d3365096c52d263b291c681f1e6b80a58a0a",
+        },
+      }
+
+      commit_data = {
+        node_id: "MDM6VGFnMTc0MzU5Mzc6YTE5OWQzMzY1MDk2YzUyZDI2M2IyOTFjNjgxZjFlNmI4MGE1OGEwYQ==",
+        sha: "a199d3365096c52d263b291c681f1e6b80a58a0a",
+        url: "https://api.github.com/repos/fac/example/git/tags/a199d3365096c52d263b291c681f1e6b80a58a0a",
+        tagger: { name: "User", email: "user@example.com", date: "2017-10-06 13:58:33 UTC" },
+        object: {
+          sha: "2871571664f3d6ac4ba02157b4c5ec93982031fd",
+          type: "commit",
+          url: "https://api.github.com/repos/fac/example/git/commits/2871571664f3d6ac4ba02157b4c5ec93982031fd"
+        },
+        tag: "example-tag",
+        message: "Example tag message\n",
+        verification: { verified: false, reason: "unsigned", signature: nil, payload: nil },
+      }
+      expect(octokit).to receive(:tag).with("fac/example", "a199d3365096c52d263b291c681f1e6b80a58a0a").and_return(commit_data)
+
+      expect(subject.get_commit_sha_from_tag(tag_data)).to eq("2871571664f3d6ac4ba02157b4c5ec93982031fd")
+    end
+
+    it "raises an error for tag pointing to non-tag/commit object" do
+      expect do
+        subject.get_commit_sha_from_tag(object: { type: "unknown" })
+      end.to raise_error(FaHarnessTools::LookupError, /non-commit object/)
+    end
+
+    it "raises an error for unknown tag SHA" do
+      expect(octokit).to receive(:tag).with("fac/example", "123456").and_raise(Octokit::NotFound)
+      expect do
+        subject.get_commit_sha_from_tag(object: { type: "tag", sha: "123456" })
+      end.to raise_error(FaHarnessTools::LookupError, /Unable to find tag/)
+    end
+  end
+end


### PR DESCRIPTION
Retrieving the last deploy tag was a slow operation, taking ~10 mins on
a repo with 16k tags. This was because `Octokit::Client#tags` is a
paginated API call to GitHub, only retrieving 30 at a time. To find the
latest deploy tag, all tags were being pulled back and then filtered and
sorted on the client.

This splits the operation into two parts - first pulling back all tag
names via the `#refs` API operation, and then retrieving the commit SHA
when we know which tag we need.

The refs retrieval supports filtering by prefix - although since most
tags in our repos have the same prefixes, this is only slightly faster.
It however has no pagination, so we can retrieve thousands of ref names
in a single API call fairly quickly, though it doesn't return commit
object information. The `#last_deploy_tag` call now runs in 5.6s against
the same repo with 16k tags, rather than 10 mins.

Fixes #9