### PR TITLE
Speed up is_ancestor_of? and branch_contains?

### DIFF
--- a/spec/github_client_spec.rb
+++ b/spec/github_client_spec.rb
@@ -172,4 +172,64 @@ describe FaHarnessTools::GithubClient do
       end.to raise_error(FaHarnessTools::LookupError, /Unable to find tag/)
     end
   end
+
+  describe "#is_ancestor_of?" do
+    it "returns true when 'commit' is related to 'ancestor'" do
+      compare_data = {
+        url: "https://api.github.com/repos/fac/example/compare/e7eabe7...5167e6c",
+        merge_base_commit: {
+          sha: "e7eabe7dd1fbe7ddf75746b6203da819e8abb65c",
+          node_id: "MDY6Q29tbWl0MTc0MzU5Mzc6ZTdlYWJlN2RkMWZiZTdkZGY3NTc0NmI2MjAzZGE4MTllOGFiYjY1Yw==",
+        },
+      }
+      allow(octokit).to receive(:commit).with("fac/example", "e7eabe7").and_return(sha: "e7eabe7dd1fbe7ddf75746b6203da819e8abb65c")
+      expect(octokit).to receive(:compare).with("fac/example", "e7eabe7", "5167e6c").and_return(compare_data)
+
+      expect(subject.is_ancestor_of?("e7eabe7", "5167e6c")).to be true
+    end
+
+    it "returns false when 'commit' and 'ancestor' are not directly related" do
+      compare_data = {
+        url: "https://api.github.com/repos/fac/example/compare/5167e6c...5167e6c",
+        merge_base_commit: {
+          sha: "e7eabe7dd1fbe7ddf75746b6203da819e8abb65c",
+          node_id: "MDY6Q29tbWl0MTc0MzU5Mzc6ZTdlYWJlN2RkMWZiZTdkZGY3NTc0NmI2MjAzZGE4MTllOGFiYjY1Yw==",
+        },
+      }
+      allow(octokit).to receive(:commit).with("fac/example", "0d0c606").and_return(sha: "0d0c6063edffee0dd0da94a66e3caafa7bde9fea")
+      expect(octokit).to receive(:compare).with("fac/example", "0d0c606", "5167e6c").and_return(compare_data)
+
+      expect(subject.is_ancestor_of?("0d0c606", "5167e6c")).to be false
+    end
+  end
+
+  describe "#branch_contains?" do
+    it "returns true when 'commit' is on the branch" do
+      compare_data = {
+        url: "https://api.github.com/repos/fac/example/compare/master...e7eabe7",
+        merge_base_commit: {
+          sha: "e7eabe7dd1fbe7ddf75746b6203da819e8abb65c",
+          node_id: "MDY6Q29tbWl0MTc0MzU5Mzc6ZTdlYWJlN2RkMWZiZTdkZGY3NTc0NmI2MjAzZGE4MTllOGFiYjY1Yw==",
+        },
+      }
+      allow(octokit).to receive(:commit).with("fac/example", "e7eabe7").and_return(sha: "e7eabe7dd1fbe7ddf75746b6203da819e8abb65c")
+      expect(octokit).to receive(:compare).with("fac/example", "e7eabe7", "master").and_return(compare_data)
+
+      expect(subject.branch_contains?("master", "e7eabe7")).to be true
+    end
+
+    it "returns false when 'commit' and 'ancestor' are not directly related" do
+      compare_data = {
+        url: "https://api.github.com/repos/fac/example/compare/master...5167e6c",
+        merge_base_commit: {
+          sha: "e7eabe7dd1fbe7ddf75746b6203da819e8abb65c",
+          node_id: "MDY6Q29tbWl0MTc0MzU5Mzc6ZTdlYWJlN2RkMWZiZTdkZGY3NTc0NmI2MjAzZGE4MTllOGFiYjY1Yw==",
+        },
+      }
+      allow(octokit).to receive(:commit).with("fac/example", "0d0c606").and_return(sha: "0d0c6063edffee0dd0da94a66e3caafa7bde9fea")
+      expect(octokit).to receive(:compare).with("fac/example", "0d0c606", "master").and_return(compare_data)
+
+      expect(subject.branch_contains?("master", "0d0c606")).to be false
+    end
+  end
 end


### PR DESCRIPTION
To check if one commit is an ancestor of another - or similarly whether
a commit is on a branch (in effect the same operation, just resolving
the branch name to its HEAD commit), GithubClient was iterating back
through commits from the candidate to see if the ancestor was in the
history.

This was usually fast if it was successful as we're normally deploying
only a few revisions on from the last deployment, so the ancestor (the
last deploy) is very close to the candidate commit. If the commit wasn't
an ancestor, then the commit history would keep being fetched until it
reached the root commit which could take a long time on a large repo.

Now the commit comparison is fetched from GitHub which provides the
merge base commit (see [git-merge-base(1)](https://git-scm.com/docs/git-merge-base)), making the result very easy
to determine as the merge base for two commits where one is the ancestor
of the other will always be the ancestor. If they're not directly
related, e.g. on a different branch, then the merge base will be a third
commit and so the check should fail.

This means the result can be computed with just two API calls and no
iteration over the commit history.

Fixes #11