### PR TITLE
Allow GITHUB_OAUTH_TOKEN to be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Examples below use [variables defined by Harness](https://docs.harness.io/articl
 
 Full scripts that can be used in Harness are available in the [examples/](examples/) directory.
 
-### Required environment variables
+### Optional environment variables
 
-* `GITHUB_OAUTH_TOKEN` must be exported, containing a valid [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for GitHub
+* To access private repositories, `GITHUB_OAUTH_TOKEN` must be exported, containing a valid [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) for GitHub
 
 ### check-branch-brotection
 

--- a/exe/check-branch-protection
+++ b/exe/check-branch-protection
@@ -32,7 +32,7 @@ OptionParser.new do |opts|
 end.parse!
 
 client = FaHarnessTools::GithubClient.new(
-  oauth_token: ENV.fetch("GITHUB_OAUTH_TOKEN"),
+  oauth_token: ENV.fetch("GITHUB_OAUTH_TOKEN", nil),
   owner: options.fetch(:github_owner),
   repo: options.fetch(:repo),
 )

--- a/lib/fa-harness-tools/github_client.rb
+++ b/lib/fa-harness-tools/github_client.rb
@@ -9,6 +9,8 @@ module FaHarnessTools
       @octokit = Octokit::Client.new(access_token: oauth_token)
       @owner = owner
       @repo = repo
+      @oauth_token = oauth_token
+      validate_repo
     end
 
     def owner_repo
@@ -114,6 +116,19 @@ module FaHarnessTools
     def create_tag(tag, message, commit_sha, *args)
       @octokit.create_ref(owner_repo, "tags/#{tag}", commit_sha)
       @octokit.create_tag(owner_repo, tag, message, commit_sha, *args)
+    end
+
+    private
+
+    # Validates a repository exists.
+    # Raises a `LookupError` in the event a repository can't be found.
+    def validate_repo
+      @octokit.repo(owner_repo)
+
+    rescue Octokit::NotFound
+      message = "Unable to find repository #{owner_repo}"
+      message = "#{message}. If the repository is private, try setting GITHUB_OAUTH_TOKEN" unless @oauth_token
+      raise LookupError, message
     end
   end
 end


### PR DESCRIPTION
allows access to public repos without defining the GITHUB_OAUTH_TOKEN in
the environment.

Addresses #2 