### PR TITLE
Add workflow to release to RubyGems on merge to master

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,8 +10,6 @@ jobs:
       - uses: actions/checkout@v1
       - name: Set up Ruby 2.5
         uses: actions/setup-ruby@v1
-        with:
-          ruby-version: 2.5.x
       - name: Build and test with Rake
         run: |
           gem install bundler -v 1.16.4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,20 +1,41 @@
-name: Ruby
+name: CICD
 
 on: [push, pull_request]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-    - name: Set up Ruby 2.5
-      uses: actions/setup-ruby@v1
-      with:
-        ruby-version: 2.5.x
-    - name: Build and test with Rake
-      run: |
-        gem install bundler -v 1.16.4
-        bundle install --jobs 4 --retry 3
-        bundle exec rake
+      - uses: actions/checkout@v1
+      - name: Set up Ruby 2.5
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.5.x
+      - name: Build and test with Rake
+        run: |
+          gem install bundler -v 1.16.4
+          bundle install --jobs 4 --retry 3
+          bundle exec rake
+
+  release:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1 # .ruby-version
+        with:
+          bundler-cache: true    # bundle install
+
+      - run: bundle exec rake build
+
+      - uses: fac/ruby-gem-setup-credentials-action@v2
+        with:
+          user: ""
+          key: rubygems
+          token: ${{ secrets.FAC_RUBYGEMS_KEY }}
+
+      - uses: fac/ruby-gem-push-action@v2
+        with:
+          key: github

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
   release:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: ${{ github.ref == 'refs/heads/master' }}
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # fa-harness-tools
 
+#### https://rubygems.org/gems/fa-harness-tools
+
 FreeAgent-specific pre-flight checks and tools that are designed to work in [Harness](https://harness.io).
 
 ## Installation
@@ -82,7 +84,9 @@ After checking out the repo, run `bin/setup` to install dependencies. You can al
 
 To install this gem onto your local machine, run `bundle exec rake install`.
 
-To release a new version, update the version number in `version.rb`, run `bundle` and commit the version bump. Then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To release a new version, update the version number in `version.rb`. After your PR is merged to master, the CICD GitHub Action workflow will release to RubyGems automatically:
+Gem is hosted publicly here:
+https://rubygems.org/gems/fa-harness-tools
 
 The Ruby version used matches the one from the `harness/delegate` Docker image.
 


### PR DESCRIPTION
Add GH action workflow, so that you don't have to manually release this gem.

Fixes: https://github.com/fac/fa-harness-tools/issues/21