### PR TITLE
Improve Pre-Flight Check Time

### DIFF
--- a/lib/fa-harness-tools/check_branch_protection.rb
+++ b/lib/fa-harness-tools/check_branch_protection.rb
@@ -1,10 +1,11 @@
 module FaHarnessTools
   # Check if the sha being deployed belongs to the given branch.
   class CheckBranchProtection
-    def initialize(client:, context:, branch:)
+    def initialize(client:, context:, branch:, new_sha:)
       @client = client
       @context = context
       @branch = branch
+      @new_sha = new_sha
       @logger = CheckLogger.new(
         name: "Check branch protection",
         description: "Only allow commits on the #{@branch} branch to be deployed",
@@ -13,15 +14,13 @@ module FaHarnessTools
 
     def verify?
       @logger.start
-      @logger.context_info(@client, @context)
-
-      new_sha = @context.new_commit_sha
+      @logger.context_info(@client, @context, @new_sha)
 
       @logger.info("checking if #{@branch} branch contains the commit")
-      if @client.branch_contains?(@branch, new_sha)
-        @logger.pass "#{@branch} contains #{new_sha}"
+      if @client.branch_contains?(@branch, @new_sha)
+        @logger.pass "#{@branch} contains #{@new_sha}"
       else
-        @logger.fail "#{@branch} does not contain #{new_sha}"
+        @logger.fail "#{@branch} does not contain #{@new_sha}"
       end
     end
   end

--- a/lib/fa-harness-tools/check_logger.rb
+++ b/lib/fa-harness-tools/check_logger.rb
@@ -16,9 +16,9 @@ module FaHarnessTools
       puts "  ... #{message}"
     end
 
-    def context_info(client, context)
+    def context_info(client, context, new_sha)
       info("we're deploying repo #{client.owner_repo} into environment #{context.environment}")
-      info("we're trying to deploy commit #{context.new_commit_sha}")
+      info("we're trying to deploy commit #{new_sha}")
     end
 
     def pass(message)


### PR DESCRIPTION
Here we are reducing the number of API calls made to improve the time it takes to run pre-flight checks.
Before Change
```
Check branch protection (Only allow commits on the master branch to be deployed)
2.6639684599940665

Check deployment schedule (Only allow deployments within certain times of the day)
0.011253540986217558

Check forward deploy (Only allow deployments that are newer than what's currently deployed)
3.6708341680059675

Check recent deploys (Only allow deployments of recent commits, up to 3 deployment rollbacks)
3.0661681249912363
```