### PR TITLE
Update Gemfile.lock with new version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fa-harness-tools (1.3.0)
+    fa-harness-tools (1.3.1)
       fugit (~> 1.3)
       octokit (~> 4.0)
       pastel (~> 0.7)


### PR DESCRIPTION
I was supposed to run bundle install after changing the version in this
PR: https://github.com/fac/fa-harness-tools/pull/26

The CI/CD process on master is failing because of this (strange that it
ran fine on the branch CI though).
