### PR TITLE
Make sure octokit has a timeout in place

### DIFF
--- a/lib/fa-harness-tools/github_client.rb
+++ b/lib/fa-harness-tools/github_client.rb
@@ -7,6 +7,13 @@ module FaHarnessTools
 
     def initialize(oauth_token:, owner:, repo:)
       @octokit = Octokit::Client.new(access_token: oauth_token)
+      @octokit.connection_options = {
+        request: {
+          open_timeout: 60,
+          timeout: 60
+        }
+      }
+
       @owner = owner
       @repo = repo
       @oauth_token = oauth_token

--- a/spec/github_client_spec.rb
+++ b/spec/github_client_spec.rb
@@ -11,6 +11,7 @@ describe FaHarnessTools::GithubClient do
 
   before do
     allow(Octokit::Client).to receive(:new).with(access_token: "none").and_return(octokit)
+    allow(octokit).to receive(:connection_options=)
     allow(octokit).to receive(:repo).with("fac/example")
   end
 


### PR DESCRIPTION
60s seems like a reasonable timeout for this. As octokit does not set a default....

See https://github.com/octokit/octokit.rb#timeouts 

I ran check-forward-deploy locally with some values and it seemed to execute fine. (although why the first recorded deployment thing I don't know. )

```
benrobinson@BRO-FA1135:~/workspace/fa-harness-tools [octokit-timeout L|✚1]% bundle exec exe/check-forward-deploy -r freeagent -e prod -b 0114d0a824251b88af35ef82adf78739b5078dcd
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
Check forward deploy (Only allow deployments that are newer than what's currently deployed)
  ... we're deploying repo fac/freeagent into environment prod
  ... we're trying to deploy commit 0114d0a824251b88af35ef82adf78739b5078dcd
  ... no harness-deploy tag was found, so this must be the first deployment
PASS: this is the first recorded deployment so is permitted
```
